### PR TITLE
Add Vercel Speed Insights to Astro Layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+dist/

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@iconify-json/skill-icons": "^1.2.3",
     "@iconify-json/vscode-icons": "^1.2.43",
     "@tailwindcss/vite": "^4.2.0",
+    "@vercel/speed-insights": "^2.0.0",
     "astro": "^6.1.3",
     "astro-icon": "^1.1.5",
     "sharp": "^0.34.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.0
         version: 4.3.0(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0
       astro:
         specifier: ^6.1.3
         version: 6.4.4(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.1)(yaml@2.9.0)
@@ -810,6 +813,32 @@ packages:
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -2804,6 +2833,8 @@ snapshots:
     optional: true
 
   '@ungap/structured-clone@1.3.1': {}
+
+  '@vercel/speed-insights@2.0.0': {}
 
   '@volar/kit@2.4.28(typescript@5.9.3)':
     dependencies:

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import '../styles/global.css'
 import { SITE_CONFIG } from '../config.ts';
 import favicon from '../../Y-Logo.png';
+import SpeedInsights from "@vercel/speed-insights/astro"
 
 interface Props {
   title: string;
@@ -228,5 +229,6 @@ const defaultTheme = `${baseTheme}-dark`;
     });
 
     </script>
+    <SpeedInsights />
   </body>
 </html>


### PR DESCRIPTION
This PR integrates Vercel Speed Insights into the project by adding the `<SpeedInsights />` component to the main Astro layout. It also includes an update to `.gitignore` to prevent build artifacts from being committed.

---
*PR created automatically by Jules for task [18012468958477679948](https://jules.google.com/task/18012468958477679948) started by @YonasGr*